### PR TITLE
add an option to supress "This channel is not used" warning

### DIFF
--- a/src/AutomatonWithGUI.tsx
+++ b/src/AutomatonWithGUI.tsx
@@ -36,6 +36,12 @@ export interface AutomatonWithGUIOptions {
   disableTimeControls?: boolean;
 
   /**
+   * Disable warnings for not used channels.
+   * Intended to be used by automaton-electron.
+   */
+  disableChannelNotUsedWarning?: boolean;
+
+  /**
    * Overrides the save procedure.
    * Originally intended to be used by automaton-electron.
    */
@@ -93,10 +99,16 @@ export class AutomatonWithGUI extends Automaton
   protected __isPlaying: boolean;
 
   /**
-   * Whether it disables any time controls or not.
+   * Whether it disables any time controls interfaces or not.
    * Can be specified via {@link AutomatonWithGUIOptions}.
    */
   private __isDisabledTimeControls: boolean = false;
+
+  /**
+   * Whether it disables not used warning for channels or not.
+   * Can be specified via {@link AutomatonWithGUIOptions}.
+   */
+  private __isDisabledChannelNotUsedWarning: boolean = false;
 
   /**
    * Whether it has any changes that is not saved yet or not.
@@ -179,6 +191,14 @@ export class AutomatonWithGUI extends Automaton
     this.overrideSave = options.overrideSave;
     this.saveContextMenuCommands = options.saveContextMenuCommands;
     this.__isDisabledTimeControls = options.disableTimeControls || false;
+    this.__isDisabledChannelNotUsedWarning = options.disableChannelNotUsedWarning || false;
+
+    // if `options.disableChannelNotUsedWarning` is true, mark every channels as used
+    if ( this.__isDisabledChannelNotUsedWarning ) {
+      Object.values( this.__channels ).forEach( ( channel ) => {
+        channel.markAsUsed();
+      } );
+    }
 
     if ( options.gui ) {
       this.__guiRemocon = new GUIRemocon();
@@ -317,6 +337,11 @@ export class AutomatonWithGUI extends Automaton
 
     const channel = new ChannelWithGUI( this, data );
     this.__channels[ name ] = channel;
+
+    // if `options.disableChannelNotUsedWarning` is true, mark the created channels as used
+    if ( this.__isDisabledChannelNotUsedWarning ) {
+      channel.markAsUsed();
+    }
 
     this.__emit( 'createChannel', { name, channel: channel } );
 


### PR DESCRIPTION
will close #3 

new option to `AutomatonWithGUI` : `disableChannelNotUsedWarning` . This will suppress the "This channel is not used" warning.