### PR TITLE
bump automaton to 3.0.0-beta3

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@ And you <code>doubleclick</code> the node, the node will be removed.
 You also can put cutting-edge <b>Fx</b>s on this timeline.
 <code>Right-click</code> on the timeline will show you a context menu, then <code>click</code>ing <code>Add Fx</code> will show you a list of Fx definition.
 Fxs deforms your animation curve into various form. Try various!
-Or do you still want to do something wacky? Call <code>automaton.addFxDefinition()</code> to define your own Fx definition!
+Or do you still want to do something wacky? Call <code>automaton.addFxDefinitions()</code> to define your own Fx definitions!
 
 You can scroll around the timeline using mouse <code>wheel</code>.
 <code>Shift-Scroll</code> lets the timeline horizontal zoom.
@@ -205,20 +205,22 @@ function update() {
 update();
 
 // == automaton the hard way: an example of a user-defined fx ======================================
-automaton.addFxDefinition( 'sawtooth', {
-  name: 'Sawtooth', // display name
-  description: 'Example of user-defined fx definition', // description of the fx definition
-  params: { // params. can be float, int or boolean
-    freq: { name: 'Frequency', type: 'float', default: 10.0, min: 0.0, max: 100.0 },
-    amp: { name: 'Amp', type: 'float', default: 0.1 }
-  },
-  func( context ) { // define your procedure here
-    if ( context.init ) {
-      context.state.saw = 0.0;
+automaton.addFxDefinitions( {
+  sawtooth: {
+    name: 'Sawtooth', // display name
+    description: 'Example of user-defined fx definition', // description of the fx definition
+    params: { // params. can be float, int or boolean
+      freq: { name: 'Frequency', type: 'float', default: 10.0, min: 0.0, max: 100.0 },
+      amp: { name: 'Amp', type: 'float', default: 0.1 }
+    },
+    func( context ) { // define your procedure here
+      if ( context.init ) {
+        context.state.saw = 0.0;
+      }
+      context.state.saw += context.params.freq * context.deltaTime;
+      context.state.saw = context.state.saw % 1.0;
+      return context.value + context.params.amp * context.state.saw;
     }
-    context.state.saw += context.params.freq * context.deltaTime;
-    context.state.saw = context.state.saw % 1.0;
-    return context.value + context.params.amp * context.state.saw;
   }
 } );
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.9.4",
-    "@fms-cat/automaton": "3.0.0-beta2",
+    "@fms-cat/automaton": "3.0.0-beta3",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.11.0",
     "@types/react": "^16.9.32",

--- a/src/AutomatonWithGUI.tsx
+++ b/src/AutomatonWithGUI.tsx
@@ -214,9 +214,7 @@ export class AutomatonWithGUI extends Automaton
     this.__isPlaying = options.isPlaying || false;
 
     if ( options.installBuiltinFxs ) {
-      Object.entries( fxDefinitions ).forEach( ( [ key, def ] ) => {
-        this.addFxDefinition( key, def );
-      } );
+      this.addFxDefinitions( fxDefinitions );
     }
 
     this.overrideSave = options.overrideSave;
@@ -276,14 +274,13 @@ export class AutomatonWithGUI extends Automaton
   }
 
   /**
-   * Add a fx definition.
-   * @param id Unique id for the Fx definition
-   * @param fxDef Fx definition object
+   * Add fx definitions.
+   * @param fxDefinitions A map of id - fx definition
    */
-  public addFxDefinition( id: string, fxDef: FxDefinition ): void {
-    super.addFxDefinition( id, fxDef );
+  public addFxDefinitions( fxDefinitions: { [ id: string ]: FxDefinition } ): void {
+    super.addFxDefinitions( fxDefinitions );
 
-    this.__emit( 'addFxDefinition', { name: id, fxDefinition: fxDef } );
+    this.__emit( 'addFxDefinitions', { fxDefinitions } );
   }
 
   /**
@@ -707,7 +704,7 @@ export interface AutomatonWithGUIEvents {
   removeChannel: { name: string };
   createCurve: { index: number; curve: CurveWithGUI };
   removeCurve: { index: number };
-  addFxDefinition: { name: string; fxDefinition: FxDefinition };
+  addFxDefinitions: { fxDefinitions: { [ id: string ]: FxDefinition } };
   changeLength: { length: number };
   changeResolution: { resolution: number };
   updateGUISettings: { settings: GUISettings };

--- a/src/view/components/AutomatonStateListener.tsx
+++ b/src/view/components/AutomatonStateListener.tsx
@@ -363,11 +363,13 @@ const AutomatonStateListener = ( props: AutomatonStateListenerProps ): JSX.Eleme
         } );
       } );
 
-      const handleAddFxDefinition = automaton.on( 'addFxDefinition', ( { name, fxDefinition } ) => {
-        dispatch( {
-          type: 'Automaton/AddFxDefinition',
-          name,
-          fxDefinition
+      const handleAddFxDefinitions = automaton.on( 'addFxDefinitions', ( { fxDefinitions } ) => {
+        Object.entries( fxDefinitions ).forEach( ( [ name, fxDefinition ] ) => {
+          dispatch( {
+            type: 'Automaton/AddFxDefinition',
+            name,
+            fxDefinition
+          } );
         } );
       } );
 
@@ -414,7 +416,7 @@ const AutomatonStateListener = ( props: AutomatonStateListenerProps ): JSX.Eleme
         automaton.off( 'changeResolution', handleChangeResolution );
         automaton.off( 'play', handlePlay );
         automaton.off( 'pause', handlePause );
-        automaton.off( 'addFxDefinition', handleAddFxDefinition );
+        automaton.off( 'addFxDefinitions', handleAddFxDefinitions );
         automaton.off( 'updateGUISettings', handleUpdateGUISettings );
         automaton.off( 'createChannel', handleCreateChannel );
         automaton.off( 'removeChannel', handleRemoveChannel );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,10 +1132,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@fms-cat/automaton@3.0.0-beta2":
-  version "3.0.0-beta2"
-  resolved "https://registry.yarnpkg.com/@fms-cat/automaton/-/automaton-3.0.0-beta2.tgz#5dcd801f461e6d91d8bd36e2292e18e56376e2af"
-  integrity sha512-mUllu9/sY2f2R3Jtv7JvsPAAvgrC3BXYihmAaq3zr3+b0bCfoLqoECjfEQ30FVJRcBxLU8G7+4qZKTZ+JQrG4Q==
+"@fms-cat/automaton@3.0.0-beta3":
+  version "3.0.0-beta3"
+  resolved "https://registry.yarnpkg.com/@fms-cat/automaton/-/automaton-3.0.0-beta3.tgz#909231dc4497cf8a4209370b3542a4520b669525"
+  integrity sha512-hvg6zOTBm69shX2Iqrp6WReQLqL0clezmyU7FsWzsCFsU6VTzYsQZSnih0Wdoelvptdt29von9h8hwxdqaDH8A==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
- bump `@fms-cat/automaton` to 3.0.0-beta3
- 🚨 event `addFxDefinition` is no longer a thing, use the new `addFxDefinitions` event instead
  - see also: https://github.com/FMS-Cat/automaton/releases/tag/v3.0.0-beta3