### PR TITLE
change var output namespace to AUTOMATON_WITH_GUI

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@ var ctx = canvas.getContext( "2d" );
 var isHalted = false;
 
 // == initialize an automaton instance =============================================================
-var automaton = new AutomatonWithGUI(
+var automaton = new AUTOMATON.AutomatonWithGUI(
   JSON.parse( `
 {"v":"2.0.0","length":5,"resolution":100,"params":{"rectX":{"nodes":[{"time":0,"value":0.2,"out":{"time":0.5,"value":0}},{"time":1,"value":0.6,"in":{"time":-0.5,"value":0},"out":{"time":0,"value":0}},{"time":1.1,"value":0,"in":{"time":0,"value":0},"out":{"time":0,"value":0}},{"time":2.2,"value":0,"in":{"time":0,"value":0},"out":{"time":0.2029702970297027,"value":0}},{"time":2.683168316831683,"value":0.2,"in":{"time":-0.0058960808318827985,"value":-0.16171574263249228},"out":{"time":0.029151407919009283,"value":0.7995551137822344}},{"time":3.0792079207920793,"value":0.8,"in":{"time":-0.26237623762376217,"value":0},"out":{"time":0,"value":0}},{"time":4,"value":0.8,"in":{"time":0,"value":0},"out":{"time":0.5,"value":0}},{"time":5,"value":0.2,"in":{"time":-0.22277227722772253,"value":0.46032643646145566}}],"fxs":[{"time":1,"length":1.2,"row":0,"def":"gravity","params":{"a":20,"e":0.5,"preserve":false},"bypass":false},{"time":2.2,"length":1.8,"row":0,"def":"cds","params":{"factor":1000,"ratio":0.15,"preserve":true},"bypass":false},{"time":4,"length":1,"row":0,"def":"sine","params":{"amp":0.2,"freq":2,"phase":0}},{"def":"lofi","bypass":false,"row":1,"time":4.5,"length":0.5,"params":{"reso":10,"relative":true,"rate":20,"round":true}}]},"rectY":{"nodes":[{"time":0,"value":0,"out":{"time":0,"value":0}},{"time":5,"value":1,"in":{"time":0,"value":0}}],"fxs":[]}},"guiSettings":{"snapActive":false,"snapTime":0.1,"snapValue":0.1}}
   ` ), // put your automaton savedata here

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@ var ctx = canvas.getContext( "2d" );
 var isHalted = false;
 
 // == initialize an automaton instance =============================================================
-var automaton = new AUTOMATON.AutomatonWithGUI(
+var automaton = new AUTOMATON_WITH_GUI.AutomatonWithGUI(
   JSON.parse( `
 {"v":"2.0.0","length":5,"resolution":100,"params":{"rectX":{"nodes":[{"time":0,"value":0.2,"out":{"time":0.5,"value":0}},{"time":1,"value":0.6,"in":{"time":-0.5,"value":0},"out":{"time":0,"value":0}},{"time":1.1,"value":0,"in":{"time":0,"value":0},"out":{"time":0,"value":0}},{"time":2.2,"value":0,"in":{"time":0,"value":0},"out":{"time":0.2029702970297027,"value":0}},{"time":2.683168316831683,"value":0.2,"in":{"time":-0.0058960808318827985,"value":-0.16171574263249228},"out":{"time":0.029151407919009283,"value":0.7995551137822344}},{"time":3.0792079207920793,"value":0.8,"in":{"time":-0.26237623762376217,"value":0},"out":{"time":0,"value":0}},{"time":4,"value":0.8,"in":{"time":0,"value":0},"out":{"time":0.5,"value":0}},{"time":5,"value":0.2,"in":{"time":-0.22277227722772253,"value":0.46032643646145566}}],"fxs":[{"time":1,"length":1.2,"row":0,"def":"gravity","params":{"a":20,"e":0.5,"preserve":false},"bypass":false},{"time":2.2,"length":1.8,"row":0,"def":"cds","params":{"factor":1000,"ratio":0.15,"preserve":true},"bypass":false},{"time":4,"length":1,"row":0,"def":"sine","params":{"amp":0.2,"freq":2,"phase":0}},{"def":"lofi","bypass":false,"row":1,"time":4.5,"length":0.5,"params":{"reso":10,"relative":true,"rate":20,"round":true}}]},"rectY":{"nodes":[{"time":0,"value":0,"out":{"time":0,"value":0}},{"time":5,"value":1,"in":{"time":0,"value":0}}],"fxs":[]}},"guiSettings":{"snapActive":false,"snapTime":0.1,"snapValue":0.1}}
   ` ), // put your automaton savedata here

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
+export type { GUISettings } from './types/GUISettings';
+export type { SerializedAutomatonWithGUI } from './types/SerializedAutomatonWithGUI';
+export type { Status } from './types/Status';
+
 export { AutomatonWithGUI } from './AutomatonWithGUI';
+export { ChannelItemWithGUI } from './ChannelItemWithGUI';
+export { ChannelWithGUI } from './ChannelWithGUI';
+export { CurveWithGUI } from './CurveWithGUI';
+
+import { AutomatonWithGUI } from './AutomatonWithGUI';
+export default AutomatonWithGUI;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ Repository: ${ packageJson.repository }`
     output: {
       path: path.join( __dirname, 'dist' ),
       filename: DEV ? 'automaton-with-gui.js' : 'automaton-with-gui.min.js',
+      library: 'AUTOMATON_WITH_GUI',
       libraryTarget: 'umd',
       globalObject: 'this',
     },


### PR DESCRIPTION
Almost same change as https://github.com/FMS-Cat/automaton/pull/48

- 💡 add a namespace AUTOMATON_WITH_GUI for var output (using <script>)
    - 🚨 You'll need `AUTOMATON_WITH_GUI.` before classes if you're using Automaton via `<script>`
    ```
    const { AutomatonWithGUI } = AUTOMATON_WITH_GUI;
    ```