### PR TITLE
fix an issue around labels deserialization

### DIFF
--- a/src/AutomatonWithGUI.tsx
+++ b/src/AutomatonWithGUI.tsx
@@ -656,7 +656,7 @@ export class AutomatonWithGUI extends Automaton
       } );
     }
 
-    this.__labels = convertedData.labels;
+    this.__labels = convertedData.labels || {};
 
     this.__guiSettings = convertedData.guiSettings ?? jsonCopy( defaultGUISettings );
 

--- a/src/compat/v2Compat.ts
+++ b/src/compat/v2Compat.ts
@@ -34,7 +34,6 @@ export function v2Compat( data: V2SerializedData ): SerializedAutomatonWithGUI {
     resolution: data.resolution,
     curves,
     channels,
-    labels: {},
     guiSettings: jsonCopy( defaultGUISettings )
   };
 

--- a/src/types/SerializedAutomatonWithGUI.ts
+++ b/src/types/SerializedAutomatonWithGUI.ts
@@ -14,7 +14,7 @@ export interface SerializedAutomatonWithGUI extends SerializedAutomaton {
   /**
    * Labels of the automaton.
    */
-  labels: { [ name: string ]: number };
+  labels?: { [ name: string ]: number };
 
   /**
    * Field that contains [[GUISettings]].
@@ -27,6 +27,5 @@ export const defaultDataWithGUI: Readonly<SerializedAutomatonWithGUI> = {
   resolution: 100,
   curves: [],
   channels: {},
-  labels: {},
   guiSettings: defaultGUISettings
 };


### PR DESCRIPTION
- fix an issue that caused by undefined labels in serialized data
- `labels` in serialized data is now okay to be undefined (optional)
