### PR TITLE
guiSettings are now optional

### DIFF
--- a/src/AutomatonWithGUI.tsx
+++ b/src/AutomatonWithGUI.tsx
@@ -658,7 +658,10 @@ export class AutomatonWithGUI extends Automaton
 
     this.__labels = convertedData.labels || {};
 
-    this.__guiSettings = convertedData.guiSettings ?? jsonCopy( defaultGUISettings );
+    this.__guiSettings = {
+      ...defaultGUISettings,
+      ...convertedData.guiSettings
+    };
 
     this.__emit( 'load' );
 

--- a/src/types/SerializedAutomatonWithGUI.ts
+++ b/src/types/SerializedAutomatonWithGUI.ts
@@ -1,4 +1,4 @@
-import { GUISettings, defaultGUISettings } from './GUISettings';
+import { GUISettings } from './GUISettings';
 import { SerializedAutomaton } from '@fms-cat/automaton';
 
 /**
@@ -19,13 +19,12 @@ export interface SerializedAutomatonWithGUI extends SerializedAutomaton {
   /**
    * Field that contains [[GUISettings]].
    */
-  guiSettings: GUISettings;
+  guiSettings?: Partial<GUISettings>;
 }
 
 export const defaultDataWithGUI: Readonly<SerializedAutomatonWithGUI> = {
   version: process.env.VERSION!,
   resolution: 100,
   curves: [],
-  channels: {},
-  guiSettings: defaultGUISettings
+  channels: {}
 };


### PR DESCRIPTION
- fix an issue that caused by undefined params of gui settings in serialized data
- guiSettings in serialized data is now okay to be undefined (optional)
