### PR TITLE
Now that's a lot of changes

### DIFF
--- a/src/ChannelItemWithGUI.ts
+++ b/src/ChannelItemWithGUI.ts
@@ -16,7 +16,7 @@ export class ChannelItemWithGUI extends ChannelItem {
    * @param isFromGUI If you're poking the method from Automaton GUI, set this to true otherwise you are going to suffer in redux hell
    */
   public getValue( time: number, isFromGUI?: boolean ): number {
-    const value = super.getValue( time );
+    const value = super.getValue( this.offset + time * this.speed );
     if ( this.curve && !isFromGUI ) {
       this.curve.setPreviewTime( time );
     }

--- a/src/ChannelItemWithGUI.ts
+++ b/src/ChannelItemWithGUI.ts
@@ -16,9 +16,9 @@ export class ChannelItemWithGUI extends ChannelItem {
    * @param isFromGUI If you're poking the method from Automaton GUI, set this to true otherwise you are going to suffer in redux hell
    */
   public getValue( time: number, isFromGUI?: boolean ): number {
-    const value = super.getValue( this.offset + time * this.speed );
+    const value = super.getValue( time );
     if ( this.curve && !isFromGUI ) {
-      this.curve.setPreviewTime( time );
+      this.curve.setPreviewTime( this.offset + time * this.speed );
     }
     return value;
   }

--- a/src/ChannelWithGUI.ts
+++ b/src/ChannelWithGUI.ts
@@ -463,15 +463,21 @@ export class ChannelWithGUI extends Channel implements Serializable<SerializedCh
    * Resize an item.
    * @param id Index of the item you want to resize
    * @param length Length
+   * @param stretch Wheter it should stretch the item or not
    */
-  public resizeItem( id: string, length: number ): void {
+  public resizeItem( id: string, length: number, stretch?: boolean ): void {
     const index = this.__getItemIndexById( id );
 
     const item = this.__items[ index ];
 
     const next = this.__items[ index + 1 ];
     const right = next ? next.time : Infinity;
+    const prevLength = item.length;
     item.length = clamp( length, 0.0, right - item.time );
+
+    if ( stretch ) {
+      item.speed *= prevLength / item.length;
+    }
 
     this.reset();
 
@@ -490,8 +496,9 @@ export class ChannelWithGUI extends Channel implements Serializable<SerializedCh
    * It's very GUI dev friendly method. yeah.
    * @param id Index of the item you want to resize
    * @param length Length
+   * @param stretch Wheter it should stretch the item or not
    */
-  public resizeItemByLeft( id: string, length: number ): void {
+  public resizeItemByLeft( id: string, length: number, stretch?: boolean ): void {
     const index = this.__getItemIndexById( id );
 
     const item = this.__items[ index ];
@@ -499,12 +506,20 @@ export class ChannelWithGUI extends Channel implements Serializable<SerializedCh
     const prev = this.__items[ index - 1 ];
 
     const left = prev ? ( prev.time + prev.length ) : 0.0;
+    const prevLength = item.length;
+    const endOffset = item.length * item.speed + item.offset;
 
     const lengthMax = item.end - left;
 
     const end = item.end;
     item.length = Math.min( Math.max( length, 0.0 ), lengthMax );
     item.time = end - item.length;
+
+    if ( stretch ) {
+      item.speed *= prevLength / item.length;
+    } else {
+      item.offset = endOffset - item.length * item.speed;
+    }
 
     this.reset();
 

--- a/src/CurveWithGUI.ts
+++ b/src/CurveWithGUI.ts
@@ -72,7 +72,7 @@ export class CurveWithGUI extends Curve {
    * Whether the curve is being used in somewhere or not.
    */
   public get isUsed(): boolean {
-    return this.getSpecificStatus( CurveStatusCode.NOT_USED ) != null;
+    return this.getSpecificStatus( CurveStatusCode.NOT_USED ) == null;
   }
 
   public constructor( automaton: AutomatonWithGUI, data?: SerializedCurve & Partial<WithID> ) {

--- a/src/CurveWithGUI.ts
+++ b/src/CurveWithGUI.ts
@@ -14,7 +14,7 @@ import { jsonCopy } from './utils/jsonCopy';
 /**
  * Handles of a new node will be created in this length.
  */
-export const CURVE_DEFAULT_HANDLE_LENGTH = 0.5;
+export const CURVE_DEFAULT_HANDLE_LENGTH = 0.1;
 
 export const CURVE_FX_ROW_MAX = 5;
 

--- a/src/view/components/CurveEditor.tsx
+++ b/src/view/components/CurveEditor.tsx
@@ -1,6 +1,6 @@
 import { MouseComboBit, mouseCombo } from '../utils/mouseCombo';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { TimeValueRange, x2t, y2v } from '../utils/TimeValueRange';
+import { TimeValueRange, x2t, y2v, snapTime, snapValue } from '../utils/TimeValueRange';
 import { useDispatch, useSelector } from '../states/store';
 import { Colors } from '../constants/Colors';
 import { CurveEditorFx } from './CurveEditorFx';
@@ -130,10 +130,12 @@ const CurveEditor = ( { className }: CurveEditorProps ): JSX.Element => {
   const {
     selectedCurve,
     range,
+    guiSettings,
     automaton
   } = useSelector( ( state ) => ( {
     selectedCurve: state.curveEditor.selectedCurve,
     range: state.curveEditor.range,
+    guiSettings: state.automaton.guiSettings,
     automaton: state.automaton.instance
   } ) );
   const { curveLength } = useSelector( ( state ) => ( {
@@ -177,11 +179,12 @@ const CurveEditor = ( { className }: CurveEditorProps ): JSX.Element => {
 
       let x = x0;
       let y = y0;
+      const timePrev = x2t( x, range, rect.width );
+      const valuePrev = y2v( y, range, rect.height );
+      let time = timePrev;
+      let value = valuePrev;
 
-      const data = curve.createNode(
-        x2t( x, range, rect.width ),
-        y2v( y, range, rect.height )
-      );
+      const data = curve.createNode( time, value );
       dispatch( {
         type: 'CurveEditor/SelectItems',
         nodes: [ data.$id ]
@@ -192,19 +195,29 @@ const CurveEditor = ( { className }: CurveEditorProps ): JSX.Element => {
           x += movementSum.x;
           y += movementSum.y;
 
-          curve.moveNodeTime( data.$id, x2t( x, range, rect.width ) );
-          curve.moveNodeValue( data.$id, y2v( y, range, rect.height ) );
+          const holdTime = event.ctrlKey || event.metaKey;
+          const holdValue = event.shiftKey;
+          const ignoreSnap = event.altKey;
+
+          time = holdTime ? timePrev : x2t( x, range, rect.width );
+          value = holdValue ? valuePrev : y2v( y, range, rect.height );
+
+          if ( !ignoreSnap ) {
+            if ( !holdTime ) { time = snapTime( time, range, rect.width, guiSettings ); }
+            if ( !holdValue ) { value = snapValue( value, range, rect.height, guiSettings ); }
+          }
+
+          curve.moveNodeTime( data.$id, time );
+          curve.moveNodeValue( data.$id, value );
         },
         () => {
           if ( selectedCurve == null ) { return; }
 
-          const t = x2t( x, range, rect.width );
-          const v = y2v( y, range, rect.height );
-          curve.moveNodeTime( data.$id, t );
-          curve.moveNodeValue( data.$id, v );
+          curve.moveNodeTime( data.$id, time );
+          curve.moveNodeValue( data.$id, value );
 
-          data.time = t;
-          data.value = v;
+          data.time = time;
+          data.value = value;
 
           dispatch( {
             type: 'History/Push',
@@ -220,7 +233,7 @@ const CurveEditor = ( { className }: CurveEditorProps ): JSX.Element => {
         }
       );
     },
-    [ range, rect, curve ]
+    [ range, rect, curve, guiSettings ]
   );
 
   const handleMouseDown = useCallback(

--- a/src/view/components/CurveEditor.tsx
+++ b/src/view/components/CurveEditor.tsx
@@ -1,6 +1,6 @@
 import { MouseComboBit, mouseCombo } from '../utils/mouseCombo';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { TimeValueRange, x2t, y2v, snapTime, snapValue } from '../utils/TimeValueRange';
+import { TimeValueRange, snapTime, snapValue, x2t, y2v } from '../utils/TimeValueRange';
 import { useDispatch, useSelector } from '../states/store';
 import { Colors } from '../constants/Colors';
 import { CurveEditorFx } from './CurveEditorFx';

--- a/src/view/components/InspectorChannelItem.tsx
+++ b/src/view/components/InspectorChannelItem.tsx
@@ -179,7 +179,8 @@ const InspectorChannelItem = ( props: Props ): JSX.Element => {
                     channel: channelName,
                     item: itemId,
                     length,
-                    lengthPrev
+                    lengthPrev,
+                    stretch: false
                   }
                 ]
               } );

--- a/src/view/components/TimelineItemConstant.tsx
+++ b/src/view/components/TimelineItemConstant.tsx
@@ -200,7 +200,8 @@ const TimelineItemConstant = ( props: TimelineItemConstantProps ): JSX.Element =
                 channel: props.channel,
                 item: item.$id,
                 length: timeEnd - time,
-                lengthPrev: timeEnd - timePrev
+                lengthPrev: timeEnd - timePrev,
+                stretch: false
               }
             ],
           } );
@@ -249,7 +250,8 @@ const TimelineItemConstant = ( props: TimelineItemConstantProps ): JSX.Element =
                 channel: props.channel,
                 item: item.$id,
                 length: time - timeBegin,
-                lengthPrev: timePrev - timeBegin
+                lengthPrev: timePrev - timeBegin,
+                stretch: false
               }
             ],
           } );

--- a/src/view/components/TimelineItemCurve.tsx
+++ b/src/view/components/TimelineItemCurve.tsx
@@ -291,7 +291,7 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
   );
 
   const grabLeft = useCallback(
-    (): void => {
+    ( stretch: boolean ): void => {
       if ( !channel ) { return; }
 
       const timePrev = item.time;
@@ -313,12 +313,12 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
             time = snapTime( time, range, size.width, guiSettings );
           }
 
-          channel.resizeItemByLeft( item.$id, timeEnd - time );
+          channel.resizeItemByLeft( item.$id, timeEnd - time, stretch );
         },
         () => {
           if ( !hasMoved ) { return; }
 
-          channel.resizeItemByLeft( item.$id, timeEnd - time );
+          channel.resizeItemByLeft( item.$id, timeEnd - time, stretch );
 
           dispatch( {
             type: 'History/Push',
@@ -329,7 +329,8 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
                 channel: props.channel,
                 item: item.$id,
                 length: timeEnd - time,
-                lengthPrev: timeEnd - timePrev
+                lengthPrev: timeEnd - timePrev,
+                stretch
               }
             ],
           } );
@@ -340,7 +341,7 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
   );
 
   const grabRight = useCallback(
-    (): void => {
+    ( stretch: boolean ): void => {
       if ( !channel ) { return; }
 
       const timePrev = item.time + item.length;
@@ -362,12 +363,12 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
             time = snapTime( time, range, size.width, guiSettings );
           }
 
-          channel.resizeItem( item.$id, time - timeBegin );
+          channel.resizeItem( item.$id, time - timeBegin, stretch );
         },
         () => {
           if ( !hasMoved ) { return; }
 
-          channel.resizeItem( item.$id, time - timeBegin );
+          channel.resizeItem( item.$id, time - timeBegin, stretch );
 
           dispatch( {
             type: 'History/Push',
@@ -378,7 +379,8 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
                 channel: props.channel,
                 item: item.$id,
                 length: time - timeBegin,
-                lengthPrev: timePrev - timeBegin
+                lengthPrev: timePrev - timeBegin,
+                stretch
               }
             ],
           } );
@@ -467,8 +469,11 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
   const handleClickLeft = useCallback(
     mouseCombo( {
       [ MouseComboBit.LMB ]: () => {
-        grabLeft();
-      }
+        grabLeft( false );
+      },
+      [ MouseComboBit.LMB + MouseComboBit.Shift ]: () => {
+        grabLeft( true );
+      },
     } ),
     [ grabLeft ]
   );
@@ -476,8 +481,11 @@ const TimelineItemCurve = ( props: TimelineItemCurveProps ): JSX.Element => {
   const handleClickRight = useCallback(
     mouseCombo( {
       [ MouseComboBit.LMB ]: () => {
-        grabRight();
-      }
+        grabRight( false );
+      },
+      [ MouseComboBit.LMB + MouseComboBit.Shift ]: () => {
+        grabRight( true );
+      },
     } ),
     [ grabRight ]
   );

--- a/src/view/history/HistoryCommand.ts
+++ b/src/view/history/HistoryCommand.ts
@@ -69,12 +69,14 @@ export type HistoryCommand = {
   item: string;
   length: number;
   lengthPrev: number;
+  stretch: boolean;
 } | {
   type: 'channel/resizeItemByLeft';
   channel: string;
   item: string;
   length: number;
   lengthPrev: number;
+  stretch: boolean;
 } | {
   type: 'channel/changeCurveSpeedAndOffset';
   channel: string;
@@ -266,16 +268,16 @@ export function parseHistoryCommand( command: HistoryCommand ): {
   } else if ( command.type === 'channel/resizeItem' ) {
     return {
       undo: ( automaton ) => automaton.getChannel( command.channel )!
-        .resizeItem( command.item, command.lengthPrev ),
+        .resizeItem( command.item, command.lengthPrev, command.stretch ),
       redo: ( automaton ) => automaton.getChannel( command.channel )!
-        .resizeItem( command.item, command.length )
+        .resizeItem( command.item, command.length, command.stretch )
     };
   } else if ( command.type === 'channel/resizeItemByLeft' ) {
     return {
       undo: ( automaton ) => automaton.getChannel( command.channel )!
-        .resizeItemByLeft( command.item, command.lengthPrev ),
+        .resizeItemByLeft( command.item, command.lengthPrev, command.stretch ),
       redo: ( automaton ) => automaton.getChannel( command.channel )!
-        .resizeItemByLeft( command.item, command.length )
+        .resizeItemByLeft( command.item, command.length, command.stretch )
     };
   } else if ( command.type === 'channel/changeCurveSpeedAndOffset' ) {
     return {


### PR DESCRIPTION
- 🐛 CurveEditor: Fix the preview of curves, that was not aware of offset and speed
- ✨ Timelines: Shift+click side of items to stretch them
- 🐛 CurveEditor: Enable snapping when create a new node
- 💡 Change the default length of handles of nodes
- 🐛 Curve: `isUsed` now returns a correct value
